### PR TITLE
refactor: switch from prettier-plugin-organize-imports to eslint import sort

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,6 +4,5 @@
   "trailingComma": "es5",
   "arrowParens": "always",
   "printWidth": 80,
-  "tabWidth": 2,
-  "plugins": ["prettier-plugin-organize-imports"]
+  "tabWidth": 2
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@ import tsParser from '@typescript-eslint/parser';
 import prettier from 'eslint-plugin-prettier';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
+import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import vitest from 'eslint-plugin-vitest';
 import globals from 'globals';
 
@@ -32,6 +33,7 @@ export default [
       'react-refresh': reactRefresh,
       prettier,
       '@typescript-eslint': tsPlugin,
+      'simple-import-sort': simpleImportSort,
     },
     rules: {
       ...js.configs.recommended.rules,
@@ -45,6 +47,8 @@ export default [
       '@typescript-eslint/no-unused-vars': 'warn',
       'react/react-in-jsx-scope': 'off',
       'react/prop-types': 'off',
+      'simple-import-sort/imports': 'error',
+      'simple-import-sort/exports': 'error',
     },
     settings: {
       react: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "jsdom": "^25.0.1",
         "msw": "^2.6.5",
         "prettier": "^3.4.1",
-        "prettier-plugin-organize-imports": "^4.1.0",
         "typescript": "~5.6.3",
         "typescript-eslint": "^8.17.0",
         "vite": "^5.4.11",
@@ -5755,23 +5754,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/prettier-plugin-organize-imports": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-4.1.0.tgz",
-      "integrity": "sha512-5aWRdCgv645xaa58X8lOxzZoiHAldAPChljr/MT0crXVOWTZ+Svl4hIWlz+niYSlO6ikE5UXkN1JrRvIP2ut0A==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "prettier": ">=2.0",
-        "typescript": ">=2.9",
-        "vue-tsc": "^2.1.0"
-      },
-      "peerDependenciesMeta": {
-        "vue-tsc": {
-          "optional": true
-        }
       }
     },
     "node_modules/pretty-bytes": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "jsdom": "^25.0.1",
     "msw": "^2.6.5",
     "prettier": "^3.4.1",
-    "prettier-plugin-organize-imports": "^4.1.0",
     "typescript": "~5.6.3",
     "typescript-eslint": "^8.17.0",
     "vite": "^5.4.11",

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -1,5 +1,6 @@
 import { cleanup } from '@testing-library/react';
 import { setupServer } from 'msw/node';
+
 import { handlers } from './src/mocks/handlers';
 
 const server = setupServer(...handlers);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
+
 import AppRoutes from './routes/routes';
 
 const App: React.FC = () => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,9 @@
+import './index.css';
+
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+
 import App from './App.tsx';
-import './index.css';
 import { worker } from './mocks/browser';
 
 if (process.env.NODE_ENV === 'development') {

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,4 +1,5 @@
 import { setupWorker } from 'msw/browser';
+
 import { handlers } from './handlers';
 
 export const worker = setupWorker(...handlers);

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from 'msw';
+
 import { generateBlogPost, mockBlogPosts } from './mockBlogPosts';
 
 export const handlers = [

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
+
 import ROUTES from '../routes';
 import { fetchBlogPosts } from '../services/blogService';
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+
 import ROUTES from '../routes';
 
 const Home: React.FC = () => {

--- a/src/pages/PostDetails.tsx
+++ b/src/pages/PostDetails.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+
 import { fetchBlogPostById } from '../services/blogService';
 
 interface BlogPost {

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense } from 'react';
 import { Route, Routes } from 'react-router-dom';
+
 import PageHelmet from '../components/PageHelmet';
 import ROUTES from './index';
 


### PR DESCRIPTION
- Removed the `prettier-plugin-organize-imports` dependency.
- Configured ESLint to handle import sorting using `eslint-plugin-simple-import-sort`.
- Updated ESLint configuration to include rules for `simple-import-sort` for both imports and exports.
- Adjusted project scripts and dependencies accordingly.
- Reformatted import statements across the codebase.